### PR TITLE
Added lower() to owner names (desktop-container)

### DIFF
--- a/desktop-container/main.tf
+++ b/desktop-container/main.tf
@@ -122,11 +122,11 @@ variable "docker_image" {
 }
 
 resource "docker_volume" "home_volume" {
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}-root"
+  name = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}-root"
 }
 
 resource "docker_image" "coder_image" {
-  name = "coder-base-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+  name = "coder-base-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   build {
     path       = "./images/"
     dockerfile = "${var.docker_image}.Dockerfile"
@@ -141,7 +141,7 @@ resource "docker_container" "workspace" {
   count = data.coder_workspace.me.start_count
   image = docker_image.coder_image.latest
   # Uses lower() to avoid Docker restriction on container names.
-  name = "coder-${data.coder_workspace.me.owner}-${lower(data.coder_workspace.me.name)}"
+  name = "coder-${lower(data.coder_workspace.me.owner)}-${lower(data.coder_workspace.me.name)}"
   # Hostname makes the shell more user friendly: coder@my-workspace:~$
   hostname = lower(data.coder_workspace.me.name)
   dns      = ["1.1.1.1"]


### PR DESCRIPTION
There is a high chance that many accounts will have capital letters. To resolve I have also added these extra tags. I haven't tested or thought too hard into it but  it may be cleaner to have the name var like this:
 ```
 name = lower("coder-base-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}")
```