### PR TITLE
chore: kasmweb client to honor path based apps

### DIFF
--- a/better-vnc/for-dogfood/build/Dockerfile
+++ b/better-vnc/for-dogfood/build/Dockerfile
@@ -15,7 +15,10 @@ RUN adduser kasm-user ssl-cert
 # Replace the line that sets the websocket path to include the application path.
 # Kasm web should only be hosted on the path "/", but just incase it is moved, this regex match
 # will only replace the websocket path if the path is in the format of "/@<username>/<appname>/apps/<appname>/"
-RUN sed "s#'websockify'#(window.location.pathname.match(/@[^\\\\/]+\\\\/[^\\\\/]+\\\\/apps\\\\/[^\\\\/]+/) ?? [''])[0]+'/websockify'#g" < $KASM_VNC_PATH/www/dist/main.bundle.js > $KASM_VNC_PATH/www/dist/main.bundle.js.tmp
+#
+# note: this effect is compiled to some location, so a restart of the container is not enough. The container needs to be
+# rebuilt from scratch (empty volume) to apply.
+RUN sed "s#'websockify'#(window.location.pathname.match(/@[^\\\\/]+\\\\/[^\\\\/]+\\\\/apps\\\\/[^\\\\/]+\\\\//) ?? [''])[0]+'websockify'#g" < $KASM_VNC_PATH/www/dist/main.bundle.js > $KASM_VNC_PATH/www/dist/main.bundle.js.tmp
 RUN mv $KASM_VNC_PATH/www/dist/main.bundle.js.tmp $KASM_VNC_PATH/www/dist/main.bundle.js
 
 USER 1000

--- a/better-vnc/for-dogfood/build/Dockerfile
+++ b/better-vnc/for-dogfood/build/Dockerfile
@@ -10,4 +10,12 @@ RUN echo "kasm-user ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 RUN DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
 RUN adduser kasm-user ssl-cert
 
+# By default, the kasm web client html page connects to `/websockify` for the websocket connection.
+# This fails for path based apps, as we need to prepend the application path.
+# Replace the line that sets the websocket path to include the application path.
+# Kasm web should only be hosted on the path "/", but just incase it is moved, this regex match
+# will only replace the websocket path if the path is in the format of "/@<username>/<appname>/apps/<appname>/"
+RUN sed "s#'websockify'#(window.location.pathname.match(/@[^\\\\/]+\\\\/[^\\\\/]+\\\\/apps\\\\/[^\\\\/]+/) ?? [''])[0]+'/websockify'#g" < $KASM_VNC_PATH/www/dist/main.bundle.js > $KASM_VNC_PATH/www/dist/main.bundle.js.tmp
+RUN mv $KASM_VNC_PATH/www/dist/main.bundle.js.tmp $KASM_VNC_PATH/www/dist/main.bundle.js
+
 USER 1000


### PR DESCRIPTION
Kasm web uses an absolute location for the websocket. Remap it to
something more dynamic to support path based apps

**This should not break subdomain apps, but I cannot test it to confirm**

I verified port forwarding still works: `coder port-forward -p 0.0.0.0:6901:6901 <workspace_name>`

[Typescript playground](https://www.typescriptlang.org/play/?#code/DYUwLgBArgTsEF4IHID0ABAogWwJ4wGtUwQBnMAOmwEMBLAO1WoAdnTUDrTsA3egYwC0zamAAWqZAG4AULHhIARKkUz+Ae3ql1oCsHUBzABRH5VUfzFGMAbQB6AHVQBdANRP7Tt05ZsPjl3dUVABKCAB+cIgbZGRnEJsABjdkAHcQACNtfgJaADNcZBCZIA)

# Before

![Screenshot from 2024-08-19 09-02-32](https://github.com/user-attachments/assets/5b009c79-374a-471e-9e08-33ca772166a7)

# After 

![Screenshot from 2024-08-19 09-38-40](https://github.com/user-attachments/assets/335ccac5-5ae6-4ff7-b5dd-5fee409e5300)

